### PR TITLE
fix graph.formula()

### DIFF
--- a/R/make.R
+++ b/R/make.R
@@ -207,7 +207,8 @@ graph.full <- function(n, directed = FALSE, loops = FALSE) { # nocov start
 #' @export
 graph.formula <- function(..., simplify = TRUE) { # nocov start
   lifecycle::deprecate_soft("2.0.0", "graph.formula()", "graph_from_literal()")
-  graph_from_literal(simplify = simplify, ...)
+  mf <- as.list(match.call())[-1]
+  graph_from_literal_i(mf)
 } # nocov end
 
 #' Create an extended chordal ring graph


### PR DESCRIPTION
A bit of a hack, but it works to simply do what `graph_from_literal()` does.

``` r
library("igraph")
#> 
#> Attaching package: 'igraph'
#> The following objects are masked from 'package:stats':
#> 
#>     decompose, spectrum
#> The following object is masked from 'package:base':
#> 
#>     union
graph.formula(x -+ z, z -+ y, x -+ y, y -+ x) 
#> Warning: `graph.formula()` was deprecated in igraph 2.0.0.
#> ℹ Please use `graph_from_literal()` instead.
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
#> IGRAPH c33a34d DN-- 3 4 -- 
#> + attr: name (v/c)
#> + edges from c33a34d (vertex names):
#> [1] x->z x->y z->y y->x
graph_from_literal(x -+ z, z -+ y, x -+ y, y -+ x)
#> IGRAPH 5ccefd2 DN-- 3 4 -- 
#> + attr: name (v/c)
#> + edges from 5ccefd2 (vertex names):
#> [1] x->z x->y z->y y->x
```

<sup>Created on 2024-01-08 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>